### PR TITLE
Add visitor log page

### DIFF
--- a/visitor_log.html
+++ b/visitor_log.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>来訪者受付台帳</title>
+<style>
+body{font-family:Arial,Helvetica,sans-serif;margin:20px;}
+    h1{margin-bottom:10px;}
+    form{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:20px;}
+    label{display:flex;flex-direction:column;font-size:14px;}
+    input,select{padding:4px;font-size:14px;}
+    table{width:100%;border-collapse:collapse;}
+    th,td{border:1px solid #666;padding:4px;font-size:14px;}
+    th{background:#f0f0f0;}
+@page {size: A4 landscape; margin:20mm;}
+    @media print{
+        body{margin:20mm;font-size:12px;margin-top:60px;margin-bottom:40px;}
+        table{page-break-inside:auto;width:100%;}
+        tr{page-break-inside:avoid;page-break-after:auto;}
+        thead{display:table-header-group;}
+        tfoot{display:table-footer-group;}
+        table,th,td{font-size:12px;}
+        header{position:fixed;top:0;left:0;right:0;text-align:center;border-bottom:1px solid #000;padding:5px;font-size:16px;}
+        footer{position:fixed;bottom:0;left:0;right:0;text-align:right;padding:5px;font-size:12px;}
+        footer::after{content:"Page " counter(page);}
+        .no-print{display:none;}
+    }
+</style>
+</head>
+<body>
+<header><h1>来訪者受付台帳</h1><div id="printDate"></div></header>
+<div class="no-print">
+<form id="entryForm">
+    <label>年月
+        <input type="month" id="monthSelect">
+    </label>
+    <label>所属会社
+        <input type="text" id="company" required>
+    </label>
+    <label>名前
+        <input type="text" id="name" required>
+    </label>
+    <label>訪問人数
+        <input type="number" id="count" min="1" value="1" required>
+    </label>
+    <label>目的
+        <input type="text" id="purpose">
+    </label>
+    <label>訪問先部署
+        <input type="text" id="department">
+    </label>
+    <label>訪問先担当者
+        <input type="text" id="contact">
+    </label>
+    <label>入室時間
+        <input type="time" id="inTime">
+    </label>
+    <label>退出時間
+        <input type="time" id="outTime">
+    </label>
+    <button type="submit">追加</button>
+</form>
+<button onclick="window.print()" class="no-print">印刷/PDF</button>
+</div>
+<table id="logTable">
+    <thead>
+        <tr>
+            <th>所属会社</th>
+            <th>名前</th>
+            <th>人数</th>
+            <th>目的</th>
+            <th>訪問先部署</th>
+            <th>訪問先担当者</th>
+            <th>入室時間</th>
+            <th>退出時間</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<footer id="pageFooter"></footer>
+<script>
+const STORAGE_KEY='visitorLogData';
+const monthSelect=document.getElementById('monthSelect');
+const form=document.getElementById('entryForm');
+const tbody=document.querySelector('#logTable tbody');
+
+function getData(){
+    const raw=localStorage.getItem(STORAGE_KEY);
+    return raw?JSON.parse(raw):{};
+}
+
+function saveData(data){
+    localStorage.setItem(STORAGE_KEY,JSON.stringify(data));
+}
+
+function currentMonth(){
+    return monthSelect.value || new Date().toISOString().slice(0,7);
+}
+
+function loadMonth(){
+    tbody.innerHTML='';
+    const data=getData();
+    const month=currentMonth();
+    const records=data[month]||[];
+    records.forEach(r=>addRow(r));
+}
+
+function addRow(record){
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${record.company}</td><td>${record.name}</td><td>${record.count}</td><td>${record.purpose||''}</td><td>${record.department||''}</td><td>${record.contact||''}</td><td>${record.inTime||''}</td><td>${record.outTime||''}</td>`;
+    tbody.appendChild(tr);
+}
+
+form.addEventListener('submit',e=>{
+    e.preventDefault();
+    const record={
+        company:form.company.value.trim(),
+        name:form.name.value.trim(),
+        count:form.count.value,
+        purpose:form.purpose.value.trim(),
+        department:form.department.value.trim(),
+        contact:form.contact.value.trim(),
+        inTime:form.inTime.value,
+        outTime:form.outTime.value
+    };
+    addRow(record);
+    const data=getData();
+    const month=currentMonth();
+    if(!data[month]) data[month]=[];
+    data[month].push(record);
+    saveData(data);
+    form.reset();
+});
+
+monthSelect.addEventListener('change',loadMonth);
+monthSelect.value=new Date().toISOString().slice(0,7);
+document.getElementById("printDate").textContent = new Date().toLocaleDateString();
+loadMonth();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a single-page visitor log in `visitor_log.html`
- record visits to localStorage and display in a table
- include A4 landscape print layout with header and page numbers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688344a5d9d88330b8f3de3ca5e7f1b2